### PR TITLE
v0.9.68

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cmdstanpy" %}
-{% set version = "0.9.75" %}
+{% set version = "0.9.68" %}
 
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://github.com/stan-dev/cmdstanpy/archive/v{{ version }}.tar.gz
-  sha256: 3eede296981e2e6ad674699efdb358ce7da3e4f2add628ee4b377ef893405168
+  sha256: e8a8f14baea79703bb7d1407077f9d97113271b35b095e168252a7f386753e03
 
 build:
   number: 0


### PR DESCRIPTION
FB Prophet has a hard dependency on v0.9.68, so make a build on a separate branch for that.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Reset the build number to `0` (if the version changed)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
